### PR TITLE
Support SVG aspect ratio

### DIFF
--- a/src/Picture.jl
+++ b/src/Picture.jl
@@ -146,16 +146,25 @@ function copy_picture(p::Picture)
 end
 
 function image_aspect_ratio(path::String)
-    local img
-    try
-        img = load(path)
-    catch e
-        if e isa ErrorException && contains(e.msg, "No applicable_loaders found")
-            error("Cannot load image to determine aspect ratio, consider setting `size_x` and `size_y` manually.")
-        else
-            rethrow(e)
+    if endswith(path, ".svg")
+        doc = readxml(path)
+        r = root(doc)
+        m = match(r"(?<height>\d*)", r["height"])
+        height = isnothing(m) ? 1 : parse(Float64, m[:height])
+        m = match(r"(?<width>\d*)", r["width"])
+        width = isnothing(m) ? 1 : parse(Float64, m[:width])
+    else
+        local img
+        try
+            img = load(path)
+        catch e
+            if e isa ErrorException && contains(e.msg, "No applicable_loaders found")
+                error("Cannot load image to determine aspect ratio, consider setting `size_x` and `size_y` manually.")
+            else
+                rethrow(e)
+            end
         end
+        height, width = size(img)
     end
-    height, width = size(img)
     return width / height
 end

--- a/test/testConstructors.jl
+++ b/test/testConstructors.jl
@@ -20,36 +20,34 @@ using Test
     end
     @testset "Picture" begin
         @test_throws ArgumentError pic = Picture("path")
-        logo_path = joinpath(PPTX.ASSETS_DIR,"julia_logo.png")
-        pic = Picture(logo_path)
-        @test pic.offset_x == 0
-        width = 150
-        pic = Picture(logo_path, top = 100, left = 120, size=width)
-        @test pic.offset_x == Int(round(120*PPTX._EMUS_PER_MM))
-        @test pic.offset_y == Int(round(100*PPTX._EMUS_PER_MM))
-        @test pic.size_x == Int(round(width*PPTX._EMUS_PER_MM))
-        ratio = PPTX.image_aspect_ratio(logo_path)
-        height = Int(round(width / ratio*PPTX._EMUS_PER_MM))
-        @test pic.size_y == height
-
-        # make setting the rid doesn't change the other values
-        pic2 = PPTX.set_rid(pic, 5)
-        @test pic2.rid == 5
-        @test pic2.source == pic.source
-        @test pic2.offset_x == pic.offset_x
-        @test pic2.offset_y == pic.offset_y
-        @test pic2.size_x == pic.size_x
-        @test pic2.size_y == pic.size_y
-
-        contains(PPTX._show_string(pic2, false), "source is \"$(pic.source)\"")
+        fnames = ["julia_logo.png", "julia_logo.svg"]
+        for fname in fnames
+            logo_path = joinpath(PPTX.ASSETS_DIR, fname)
+            pic = Picture(logo_path)
+            @test pic.offset_x == 0
+            width = 150
+            pic = Picture(logo_path, top = 100, left = 120, size=width)
+            @test pic.offset_x == Int(round(120*PPTX._EMUS_PER_MM))
+            @test pic.offset_y == Int(round(100*PPTX._EMUS_PER_MM))
+            @test pic.size_x == Int(round(width*PPTX._EMUS_PER_MM))
+            ratio = PPTX.image_aspect_ratio(logo_path)
+            height = Int(round(width / ratio*PPTX._EMUS_PER_MM))
+            @test pic.size_y == height
+    
+            # make setting the rid doesn't change the other values
+            pic2 = PPTX.set_rid(pic, 5)
+            @test pic2.rid == 5
+            @test pic2.source == pic.source
+            @test pic2.offset_x == pic.offset_x
+            @test pic2.offset_y == pic.offset_y
+            @test pic2.size_x == pic.size_x
+            @test pic2.size_y == pic.size_y
+    
+            contains(PPTX._show_string(pic2, false), "source is \"$(pic.source)\"")
+        end
     end
     @testset "Picture - custom aspect ratio" begin
-        # SVG is not supported by FileIO.jl
-        # this means we need to manually set the aspect ratio
         logo_path = joinpath(PPTX.ASSETS_DIR,"julia_logo.svg")
-        msg = "Cannot load image to determine aspect ratio, consider setting `size_x` and `size_y` manually."
-        @test_throws ErrorException(msg) pic = Picture(logo_path)
-
         pic = Picture(logo_path; size_x=40, size_y=30)
         @test pic.size_x == 1440000
         @test pic.size_y == 1080000


### PR DESCRIPTION
Now both of these have correct aspect ratio and have the same width.  In v0.6.2 one had to specify `size_x` and `size_y` for the SVG file.
```
logo = Picture(joinpath(pwd(), "julia-logo-color.png"), size=100)
logo2 = Picture(joinpath(pwd(), "julia-logo-color.svg"), size=100)
```
