### PR TITLE
Refer to "[Content_Types].xml" without ".."

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PPTX"
 uuid = "14a86994-10a4-4a7d-b9ad-ef6f3b1fac6a"
 authors = ["Xander de Vries", "Matthijs Cox"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/write.jl
+++ b/src/write.jl
@@ -68,8 +68,8 @@ function update_table_style!(unzipped_ppt_dir::String=".")
     end
 end
 
-function add_contenttypes!()
-    path = joinpath("..", "[Content_Types].xml")
+function add_contenttypes!(tmpdir, unzipped_dir)
+    path = joinpath(tmpdir, unzipped_dir, "[Content_Types].xml")
     doc = readxml(path)
     r = root(doc)
     extension_contenttypes = (
@@ -183,7 +183,7 @@ function Base.write(
                 write_slides!(p)
                 write_shapes!(p)
                 update_table_style!()
-                add_contenttypes!()
+                add_contenttypes!(tmpdir, unzipped_dir)
             end
             zip(unzipped_dir, filename)
             cp(filename, filepath)


### PR DESCRIPTION
PPTX.jl v0.6.4 showed permission denied error https://github.com/ASML-Labs/PPTX.jl/pull/42#issuecomment-1682224945 .

I could reproduce that with released v0.6.4, but not with `]dev`-ed version.  This PR is to remove `..` from the path and build the path using variables.

I upped the version number, because if dev-version works, how to debug.