### PR TITLE
Add content types, try2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PPTX"
 uuid = "14a86994-10a4-4a7d-b9ad-ef6f3b1fac6a"
 authors = ["Xander de Vries", "Matthijs Cox"]
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/write.jl
+++ b/src/write.jl
@@ -68,6 +68,32 @@ function update_table_style!(unzipped_ppt_dir::String=".")
     end
 end
 
+function add_contenttypes!()
+    path = joinpath("..", "[Content_Types].xml")
+    doc = readxml(path)
+    r = root(doc)
+    extension_contenttypes = (
+        ("emf", "image/x-emf"),
+        ("gif", "image/gif"),
+        ("jpeg", "image/jpeg"),
+        ("jpg", "application/octet-stream"),
+        ("png", "image/png"),
+        ("svg", "image/svg+xml"),
+        ("tif", "application/octet-stream"),
+        ("wmf", "image/x-wmf")
+    )
+    for extension_contenttype in extension_contenttypes
+        ext, ct = extension_contenttype
+        # do not add the extension if it is already defined in the template
+        isnothing(findfirst(x -> (x.name == "Default" && x["Extension"] == ext), elements(r))) || continue
+        addelement!(r, "Default Extension=\"$ext\" ContentType=\"$ct\"")
+    end
+    chmod(path, 0o644)
+    open(path, "w") do io
+        prettyprint(io, doc)
+    end
+end
+
 """
 ```julia
 Base.write(
@@ -158,6 +184,7 @@ function Base.write(
                 write_slides!(p)
                 write_shapes!(p)
                 update_table_style!()
+                add_contenttypes!()
             end
             zip(unzipped_dir, filename)
             cp(filename, filepath)


### PR DESCRIPTION
File `[Content_Types].xml` was in mode `0o444` when we tried to overwrite it.  Add write permission with `chmod(path, 0o644)`.

Should fix #45.