### PR TITLE
Avoid using `cp` in tests

### DIFF
--- a/test/testWriting.jl
+++ b/test/testWriting.jl
@@ -92,7 +92,7 @@ end
         template_name = "no-slides.pptx"
         original_template_path = joinpath(PPTX.TEMPLATE_DIR, template_name)
         edited_template_path = joinpath(tmpdir, template_name)
-        cp(original_template_path, edited_template_path)
+        write(edited_template_path, read(original_template_path))
         zip_append_archive(edited_template_path) do w
             # add an existing media directory
             zip_newfile(w, "ppt/media/foo.png")


### PR DESCRIPTION
This should fix the PkgEval issue https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2024-05/08/PPTX.primary.log

The `cp` is making the template file being edited read-only, so I replaced it with a `write` and `read`.