### PR TITLE
Bake in default tableStyles.xml to improve PackageCompiler.jl support

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -11,3 +11,6 @@ const TESTDATA_DIR = abspath(joinpath(@__DIR__, "..", "test/testdata"))
 # we use layoutSlide1 for the first title slide, and layoutSlide2 for all other slides
 const TITLE_SLIDE_LAYOUT = 1
 const DEFAULT_SLIDE_LAYOUT = 2
+
+include_dependency(joinpath(TEMPLATE_DIR, "tableStyles.xml"))
+const DEFAULT_TABLE_STYLE_DATA = read(joinpath(TEMPLATE_DIR, "tableStyles.xml"))

--- a/src/write.jl
+++ b/src/write.jl
@@ -66,13 +66,9 @@ function update_table_style!(w::ZipWriter, template::ZipBufferReader)
     table_style_path = "ppt/tableStyles.xml"
     table_style_doc = EzXML.parsexml(zip_readentry(template, table_style_path))
     if has_empty_table_list(table_style_doc)
-        table_style_filename = "tableStyles.xml"
-        default_table_style_file = joinpath(TEMPLATE_DIR, table_style_filename)
-        open(default_table_style_file) do io
-            zip_newfile(w, table_style_path; compress=true)
-            write(w, io)
-            zip_commitfile(w)
-        end
+        zip_newfile(w, table_style_path; compress=true)
+        write(w, DEFAULT_TABLE_STYLE_DATA)
+        zip_commitfile(w)
     end
     nothing
 end

--- a/test/testWriting.jl
+++ b/test/testWriting.jl
@@ -83,6 +83,9 @@ end
         # the dark theme contains this node, which is named "<a:clrScheme name=\"Office\">" in the original theme
         str = zip_readentry(output_zip, theme_file, String)
         @test contains(str, "<a:clrScheme name=\"Office Theme\">")
+
+        # make sure table styles are not empty
+        @test PPTX.DEFAULT_TABLE_STYLE_DATA == zip_readentry(output_zip, "ppt/tableStyles.xml")
     end
 end
 


### PR DESCRIPTION
The default "tableStyles.xml" is less than 3 kB. This PR reads it into a constant at precompile time.

This PR doesn't solve the PackageCompiler.jl issue for the other template files: for a possible solution to that see #49