### PR TITLE
Added UUIDs to the filename method to ensure non-duplicate filenames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"
 

--- a/src/Picture.jl
+++ b/src/Picture.jl
@@ -1,4 +1,4 @@
-using FileIO, ImageIO
+using FileIO, ImageIO, UUIDs
 
 """
 ```julia
@@ -46,6 +46,10 @@ struct Picture <: AbstractShape
     size_x::Int
     size_y::Int
     rid::Int
+    _uuid::String
+    function Picture(source::String, offset_x::Int, offset_y::Int, size_x::Int, size_y::Int, rid::Int)
+        new(source, offset_x, offset_y, size_x, size_y, rid, string(UUIDs.uuid4()))
+    end
 end
 
 function Picture(
@@ -127,7 +131,10 @@ end
 function type_schema(p::Picture)
     return "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
 end
-filename(p::Picture) = splitpath(p.source)[end]
+function filename(p::Picture) 
+    source_filename, extension = splitext(splitpath(p.source)[end])
+    return "$(source_filename)_$(p._uuid)$extension"
+end
 
 function relationship_xml(p::Picture)
     return Dict(


### PR DESCRIPTION
Right now, if we have different image sources with the same filename the package can not handle this.
Introduce UUID in the Picture struct, and use it to generate unique filenames. 