### PR TITLE
Bake in default template to improve PackageCompiler support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -14,3 +14,6 @@ const DEFAULT_SLIDE_LAYOUT = 2
 
 include_dependency(joinpath(TEMPLATE_DIR, "tableStyles.xml"))
 const DEFAULT_TABLE_STYLE_DATA = read(joinpath(TEMPLATE_DIR, "tableStyles.xml"))
+
+include_dependency(joinpath(TEMPLATE_DIR, "no-slides.pptx"))
+const DEFAULT_TEMPLATE_DATA = read(joinpath(TEMPLATE_DIR, "no-slides.pptx"))

--- a/src/write.jl
+++ b/src/write.jl
@@ -98,6 +98,19 @@ function add_contenttypes!(w::ZipWriter, template::ZipBufferReader)
     zip_commitfile(w)
 end
 
+# Support reading a template from file path or from pre-read file data.
+function read_template(template_path::AbstractString)
+    template_path = abspath(template_path)
+    template_isfile = isfile(template_path)
+    if !template_isfile
+        error(
+            "No file found at template path: $(repr(template_path))",
+        )
+    end
+    read(template_path)
+end
+read_template(template_data::AbstractVector{UInt8}) = template_data
+
 """
 ```julia
 Base.write(
@@ -139,20 +152,7 @@ function Base.write(
     open_ppt::Bool=true,
     template_path::Union{String, Vector{UInt8}}=DEFAULT_TEMPLATE_DATA,
 )
-    template_data = if template_path isa AbstractString
-        template_path = abspath(template_path)
-        template_isfile = isfile(template_path)
-
-        if !template_isfile
-            error(
-                "No file found at template path: $(repr(template_path))",
-            )
-        end
-        read(template_path)
-    else
-        template_path
-    end
-    template_reader = ZipBufferReader(template_data)
+    template_reader = ZipBufferReader(read_template(template_path))
 
     if !endswith(filepath, ".pptx")
         filepath *= ".pptx"

--- a/src/write.jl
+++ b/src/write.jl
@@ -137,18 +137,22 @@ function Base.write(
     p::Presentation;
     overwrite::Bool=false,
     open_ppt::Bool=true,
-    template_path::String=joinpath(TEMPLATE_DIR, "no-slides.pptx"),
+    template_path::Union{String, Vector{UInt8}}=DEFAULT_TEMPLATE_DATA,
 )
+    template_data = if template_path isa AbstractString
+        template_path = abspath(template_path)
+        template_isfile = isfile(template_path)
 
-    template_path = abspath(template_path)
-    template_isfile = isfile(template_path)
-
-    if !template_isfile
-        error(
-            "No file found at template path: $(repr(template_path))",
-        )
+        if !template_isfile
+            error(
+                "No file found at template path: $(repr(template_path))",
+            )
+        end
+        read(template_path)
+    else
+        template_path
     end
-    template_reader = ZipBufferReader(read(template_path))
+    template_reader = ZipBufferReader(template_data)
 
     if !endswith(filepath, ".pptx")
         filepath *= ".pptx"


### PR DESCRIPTION
This fixes #15 and is an alternative to #49.

The default template "no-slides.pptx" is less than 35 kB. This PR reads it into a constant at precompile time.
This PR allows passing a `Vector{UInt8}` of pre-read template data in the `template_path` argument to `write`.

The main advantage of this over #49 is that it is easier to edit the default template and there is no need to find someplace to store the artifact.

I also added a `.gitattributes` file to prevent GitHub Windows CI from changing the file endings: https://code.visualstudio.com/docs/devcontainers/tips-and-tricks#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files This is to ensure the baked in data is the same bytes on all systems.