### PR TITLE
adding wrap option to TextBox

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PPTX"
 uuid = "14a86994-10a4-4a7d-b9ad-ef6f3b1fac6a"
 authors = ["Xander de Vries", "Matthijs Cox"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/test/testSlideXML.jl
+++ b/test/testSlideXML.jl
@@ -21,6 +21,13 @@ using Colors
     @test any(x->get(x, "b", false)=="1", style_xml)
     @test any(x->get(x, "sz", false)=="2400", style_xml)
 
+    # default wrap is false
+    body_xml = PPTX.make_textbody_xml(text_box)
+    @test body_xml["p:txBody"][1]["a:bodyPr"][1]["wrap"] == "none"
+    # wrap is true, gives square wrapping
+    body_xml = PPTX.make_textbody_xml(TextBox(content="bla", wrap=true))
+    @test body_xml["p:txBody"][1]["a:bodyPr"][1]["wrap"] == "square"
+
     s = Slide()
 
     # add complex text box


### PR DESCRIPTION
Text is default not wrapped in the shape. This PR allows users to wrap text in the shape with `TextBox("text", wrap=true)`.

Fixes https://github.com/ASML-Labs/PPTX.jl/issues/72